### PR TITLE
Add Support For Local LLMs

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -25,6 +25,7 @@ clang = "*"
 langchain = "*"
 langchain-openai = "*"
 langchain-community = "*"
+langchain-ollama = "*"
 lizard = "*"
 
 [dev-packages]

--- a/config.json
+++ b/config.json
@@ -90,10 +90,10 @@
       "system": [
         {
           "role": "System",
-          "content": "From now on, act as an Automated Code Repair Tool that repairs AI C code. You will be shown AI C code, along with ESBMC output. Pay close attention to the ESBMC output, which contains a stack trace along with the type of error that occurred and its location. "
+          "content": "From now on, act as an Automated Code Repair Tool that repairs AI C code. You will be shown AI C code, along with ESBMC output. Pay close attention to the ESBMC output, which contains a stack trace along with the type of error that occurred and its location that you need to fix. Provide the repaired C code as output, as would an Automated Code Repair Tool. Aside from the corrected source code, do not output any other text."
         }
       ],
-      "initial": "Provide the repaired C code as output, as would an Automated Code Repair Tool. Aside from the corrected source code, do not output any other text. The ESBMC output is {esbmc_output} The source code is {source_code}"
+      "initial": "The ESBMC output is:\n\n```\n{esbmc_output}\n```\n\nThe source code is:\n\n```c\n{source_code}\n```\n Using the ESBMC output, show the fixed text."
     }
   }
 }

--- a/esbmc_ai/__main__.py
+++ b/esbmc_ai/__main__.py
@@ -11,12 +11,13 @@ import sys
 import readline
 from typing import Optional
 
+from langchain_core.language_models import BaseChatModel
+
 from esbmc_ai.commands.fix_code_command import FixCodeCommandResult
 
 _ = readline
 
 import argparse
-from langchain.base_language import BaseLanguageModel
 
 
 import esbmc_ai.config as config
@@ -365,7 +366,7 @@ def main() -> None:
     del esbmc_output
 
     printv(f"Initializing the LLM: {config.ai_model.name}\n")
-    chat_llm: BaseLanguageModel = config.ai_model.create_llm(
+    chat_llm: BaseChatModel = config.ai_model.create_llm(
         api_keys=config.api_keys,
         temperature=config.chat_prompt_user_mode.temperature,
         requests_max_tries=config.requests_max_tries,

--- a/esbmc_ai/chats/__init__.py
+++ b/esbmc_ai/chats/__init__.py
@@ -1,5 +1,8 @@
 # Author: Yiannis Charalambous
 
+"""This module contains different chat interfaces. Along with `BaseChatInterface`
+that provides necessary boilet-plate for implementing an LLM based chat."""
+
 from .base_chat_interface import BaseChatInterface
 from .latest_state_solution_generator import LatestStateSolutionGenerator
 from .solution_generator import SolutionGenerator

--- a/esbmc_ai/chats/solution_generator.py
+++ b/esbmc_ai/chats/solution_generator.py
@@ -2,8 +2,8 @@
 
 from re import S
 from typing import Optional
+from langchain_core.language_models import BaseChatModel
 from typing_extensions import override
-from langchain.base_language import BaseLanguageModel
 from langchain.schema import BaseMessage, HumanMessage
 
 from esbmc_ai.chat_response import ChatResponse, FinishReason
@@ -83,7 +83,7 @@ class SolutionGenerator(BaseChatInterface):
     def __init__(
         self,
         ai_model_agent: DynamicAIModelAgent | ChatPromptSettings,
-        llm: BaseLanguageModel,
+        llm: BaseChatModel,
         ai_model: AIModel,
         scenario: str = "",
         source_code_format: str = "full",

--- a/esbmc_ai/chats/user_chat.py
+++ b/esbmc_ai/chats/user_chat.py
@@ -1,8 +1,8 @@
 # Author: Yiannis Charalambous 2023
 
+from langchain_core.language_models import BaseChatModel
 from typing_extensions import override
 
-from langchain.base_language import BaseLanguageModel
 from langchain.memory import ConversationSummaryMemory
 from langchain_community.chat_message_histories import ChatMessageHistory
 
@@ -21,7 +21,7 @@ class UserChat(BaseChatInterface):
         self,
         ai_model_agent: ChatPromptSettings,
         ai_model: AIModel,
-        llm: BaseLanguageModel,
+        llm: BaseChatModel,
         source_code: str,
         esbmc_output: str,
         set_solution_messages: AIAgentConversation,

--- a/esbmc_ai/chats/user_chat.py
+++ b/esbmc_ai/chats/user_chat.py
@@ -1,12 +1,12 @@
 # Author: Yiannis Charalambous 2023
 
-from langchain_core.language_models import BaseChatModel
 from typing_extensions import override
 
 from langchain.memory import ConversationSummaryMemory
+from langchain.schema import BaseMessage, SystemMessage
+from langchain_core.language_models import BaseChatModel
 from langchain_community.chat_message_histories import ChatMessageHistory
 
-from langchain.schema import BaseMessage, SystemMessage
 
 from esbmc_ai.config import AIAgentConversation, ChatPromptSettings
 from esbmc_ai.ai_models import AIModel

--- a/tests/regtest/_regtest_outputs/test_base_chat_interface.test_send_message.out
+++ b/tests/regtest/_regtest_outputs/test_base_chat_interface.test_send_message.out
@@ -1,3 +1,14 @@
-(SystemMessage(content='System message'), AIMessage(content='OK'))
-[HumanMessage(content='Test 1'), AIMessage(content='OK 1'), HumanMessage(content='Test 2'), AIMessage(content='OK 2'), HumanMessage(content='Test 3'), AIMessage(content='OK 3')]
-[ChatResponse(message=AIMessage(content='OK 1'), total_tokens=15, finish_reason=<FinishReason.stop: 1>), ChatResponse(message=AIMessage(content='OK 2'), total_tokens=23, finish_reason=<FinishReason.stop: 1>), ChatResponse(message=AIMessage(content='OK 3'), total_tokens=31, finish_reason=<FinishReason.stop: 1>)]
+System Messages:
+system: System message
+ai: OK
+Chat Messages:
+human: Test 1
+ai: OK 1
+human: Test 2
+ai: OK 2
+human: Test 3
+ai: OK 3
+Responses:
+ai(15 - FinishReason.stop): OK 1
+ai(23 - FinishReason.stop): OK 2
+ai(31 - FinishReason.stop): OK 3

--- a/tests/regtest/test_base_chat_interface.py
+++ b/tests/regtest/test_base_chat_interface.py
@@ -1,8 +1,8 @@
 # Author: Yiannis Charalambous
 
+from langchain_core.language_models import FakeListChatModel
 import pytest
 
-from langchain_community.llms import FakeListLLM
 from langchain.schema import BaseMessage, HumanMessage, AIMessage, SystemMessage
 
 from esbmc_ai.ai_models import AIModel
@@ -14,7 +14,7 @@ from esbmc_ai.config import AIAgentConversation, ChatPromptSettings
 @pytest.fixture
 def setup():
     responses: list[str] = ["OK 1", "OK 2", "OK 3"]
-    llm: FakeListLLM = FakeListLLM(responses=responses)
+    llm: FakeListChatModel = FakeListChatModel(responses=responses)
 
     ai_model: AIModel = AIModel("test", 1024)
 
@@ -64,6 +64,13 @@ def test_send_message(regtest, setup) -> None:
     ]
 
     with regtest:
-        print(chat.ai_model_agent.system_messages.messages)
-        print(chat.messages)
-        print(chat_responses)
+        print("System Messages:")
+        for m in chat.ai_model_agent.system_messages.messages:
+            print(f"{m.type}: {m.content}")
+        print("Chat Messages:")
+        for m in chat.messages:
+            print(f"{m.type}: {m.content}")
+        print("Responses:")
+        for m in chat_responses:
+            print(f"{m.message.type}({m.total_tokens} - {m.finish_reason}): {m.message.content}")
+

--- a/tests/test_ai_models.py
+++ b/tests/test_ai_models.py
@@ -15,7 +15,7 @@ from esbmc_ai.ai_models import (
     AIModel,
     _AIModels,
     get_ai_model_by_name,
-    AIModelTextGen,
+    OllamaAIModel,
     _get_openai_model_max_tokens,
 )
 
@@ -93,19 +93,15 @@ def test_apply_chat_template() -> None:
     assert prompt == ChatPromptValue(messages=messages)
 
     # Test the text gen method
-    custom_model_2: AIModelTextGen = AIModelTextGen(
+    custom_model_2: OllamaAIModel = OllamaAIModel(
         name="custom",
         tokens=999,
         url="",
-        config_message="{history}\n\n{user_prompt}",
-        ai_template="AI: {content}",
-        human_template="Human: {content}",
-        system_template="System: {content}",
     )
 
     prompt_text: str = custom_model_2.apply_chat_template(messages=messages).to_string()
 
-    assert prompt_text == "System: M1\n\nHuman: M2\n\nAI: M3"
+    assert prompt_text == "System: M1\nHuman: M2\nAI: M3"
 
 
 def test_escape_messages() -> None:

--- a/tests/test_base_chat_interface.py
+++ b/tests/test_base_chat_interface.py
@@ -1,8 +1,8 @@
 # Author: Yiannis Charalambous
 
+from langchain_core.language_models import FakeListChatModel
 import pytest
 
-from langchain_community.llms import FakeListLLM
 from langchain.schema import AIMessage, BaseMessage, HumanMessage, SystemMessage
 from esbmc_ai.ai_models import AIModel
 from esbmc_ai.chats.base_chat_interface import BaseChatInterface
@@ -23,7 +23,7 @@ def setup():
 
 
 def test_push_message_stack(setup) -> None:
-    llm: FakeListLLM = FakeListLLM(responses=[])
+    llm: FakeListChatModel = FakeListChatModel(responses=[])
 
     ai_model, system_messages = setup
 
@@ -56,7 +56,7 @@ def test_push_message_stack(setup) -> None:
 
 def test_send_message(setup) -> None:
     responses: list[str] = ["OK 1", "OK 2", "OK 3"]
-    llm: FakeListLLM = FakeListLLM(responses=responses)
+    llm: FakeListChatModel = FakeListChatModel(responses=responses)
 
     ai_model, system_messages = setup
 
@@ -98,7 +98,7 @@ def test_apply_template() -> None:
         "Replace with also replaced message",
         "replacedalso replaced",
     ]
-    llm: FakeListLLM = FakeListLLM(responses=responses)
+    llm: FakeListChatModel = FakeListChatModel(responses=responses)
 
     chat: BaseChatInterface = BaseChatInterface(
         ai_model_agent=ChatPromptSettings(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -80,12 +80,7 @@ def test_load_custom_ai() -> None:
         "example_ai": {
             "max_tokens": 4096,
             "url": "www.example.com",
-            "config_message": {
-                "template": "example",
-                "system": "{content}",
-                "ai": "{content}",
-                "human": "{content}",
-            },
+            "server_type": "ollama"
         }
     }
 

--- a/tests/test_latest_state_solution_generator.py
+++ b/tests/test_latest_state_solution_generator.py
@@ -1,10 +1,10 @@
 # Author: Yiannis Charalambous
 
 from typing import Optional
+from langchain_core.language_models import FakeListChatModel
 import pytest
 
 from langchain.schema import HumanMessage, AIMessage, SystemMessage
-from langchain_community.llms.fake import FakeListLLM
 
 from esbmc_ai.ai_models import AIModel
 from esbmc_ai.chat_response import ChatResponse
@@ -14,7 +14,7 @@ from esbmc_ai.chats.latest_state_solution_generator import LatestStateSolutionGe
 
 @pytest.fixture(scope="function")
 def setup_llm_model():
-    llm = FakeListLLM(
+    llm = FakeListChatModel(
         responses=[
             "This is a test response",
             "Another test response",

--- a/tests/test_reverse_order_solution_generator.py
+++ b/tests/test_reverse_order_solution_generator.py
@@ -1,5 +1,6 @@
 # Author: Yiannis Charalambous
 
+from langchain_core.language_models import FakeListChatModel
 import pytest
 
 from langchain.schema import (
@@ -7,7 +8,6 @@ from langchain.schema import (
     AIMessage,
     SystemMessage,
 )
-from langchain_community.llms.fake import FakeListLLM
 
 from esbmc_ai.ai_models import AIModel
 from esbmc_ai.config import AIAgentConversation, ChatPromptSettings
@@ -16,7 +16,7 @@ from esbmc_ai.reverse_order_solution_generator import ReverseOrderSolutionGenera
 
 @pytest.fixture(scope="function")
 def setup_llm_model():
-    llm = FakeListLLM(
+    llm = FakeListChatModel(
         responses=[
             "This is a test response",
             "Another test response",

--- a/tests/test_user_chat.py
+++ b/tests/test_user_chat.py
@@ -1,8 +1,8 @@
 # Author: Yiannis Charalambous
 
+from langchain_core.language_models import FakeListChatModel
 import pytest
 
-from langchain_community.llms import FakeListLLM
 from langchain.schema import AIMessage, SystemMessage
 
 from esbmc_ai.ai_models import AIModel
@@ -30,7 +30,7 @@ def setup():
             temperature=1.0,
         ),
         ai_model=AIModel(name="test", tokens=12),
-        llm=FakeListLLM(responses=[summary_text]),
+        llm=FakeListChatModel(responses=[summary_text]),
         source_code="This is source code",
         esbmc_output="This is esbmc output",
         set_solution_messages=AIAgentConversation.from_seq(set_solution_messages),


### PR DESCRIPTION
The following PR adds support for local LLMs that are running through an Ollama server. As the `TextGenerationInference` custom AIs were no longer supported, the config object `ai_custom` has been repurposed for specifying Ollama models to connect to. The reason Ollama was chosen is due to the wide array of available models that they support. As Ollama supports ChatModels directly (rather than text completion models), the ESBMC-AI code has been adapted to use Chat style code only from Lang Chain for simplicity. Additionally, the parameter `server_type` has been added, which in the future could provide additional types of server support. Currently, it only supports `ollama`.

This PR closes #138

Example config:

```json
"ai_custom": {
    "llama3.1:70b": {
      "server_type": "ollama",
      "url": "localhost:11434",
      "max_tokens": 128000
    },
    "falcon2:11b": {
      "server_type": "ollama",
      "url": "localhost:11434",
      "max_tokens": 8192
    },
    "mixtral:8x22b": {
      "server_type": "ollama",
      "url": "localhost:11434",
      "max_tokens": 64000
    }
  }
```