### PR TITLE
Addon Support for ChatCommand

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5.3.0
         with:
-          python-version: "3.11"
+          python-version: "3.12.0"
 
       - name: Check out repository code
         uses: actions/checkout@v4.2.2
@@ -43,7 +43,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5.3.0
         with:
-          python-version: "3.11"
+          python-version: "3.12.0"
 
       - name: Install pipenv
         run: |
@@ -71,7 +71,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5.3.0
         with:
-          python-version: "3.11"
+          python-version: "3.12.0"
 
       - name: Download Requirements
         uses: actions/download-artifact@v4.1.8

--- a/.pylintrc
+++ b/.pylintrc
@@ -434,7 +434,8 @@ disable=raw-checker-failed,
         unspecified-encoding,
         too-many-arguments,
         too-many-positional-arguments,
-        too-many-instance-attributes
+        too-many-instance-attributes,
+        too-few-public-methods
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/esbmc_ai/ai_models.py
+++ b/esbmc_ai/ai_models.py
@@ -49,9 +49,10 @@ class AIModel(object):
     def convert_messages_to_tuples(
         cls, messages: Iterable[BaseMessage]
     ) -> list[tuple[str, str]]:
-        """Converts messages into a format understood by the ChatPromptTemplate - since it won't format
-        BaseMessage derived classes for some reason, but will for tuples, because they get converted into
-        Templates in function `_convert_to_message`."""
+        """Converts messages into a format understood by the ChatPromptTemplate,
+        since it won't format BaseMessage derived classes for some reason, but
+        will for tuples, because they get converted into Templates in function
+        `_convert_to_message`."""
         return [(message.type, str(message.content)) for message in messages]
 
     @classmethod

--- a/esbmc_ai/chats/base_chat_interface.py
+++ b/esbmc_ai/chats/base_chat_interface.py
@@ -5,7 +5,6 @@ conversation-based way."""
 
 from abc import abstractmethod
 from typing import Optional
-import traceback
 
 from langchain.schema import (
     BaseMessage,

--- a/esbmc_ai/chats/reverse_order_solution_generator.py
+++ b/esbmc_ai/chats/reverse_order_solution_generator.py
@@ -1,5 +1,7 @@
 # Author: Yiannis Charalambous
 
+"""This module contains the ReverseOrderSolutionGenerator"""
+
 from langchain.schema import BaseMessage
 from typing_extensions import override, Optional
 from esbmc_ai.chats.solution_generator import SolutionGenerator

--- a/esbmc_ai/command_runner.py
+++ b/esbmc_ai/command_runner.py
@@ -1,0 +1,51 @@
+import re
+from esbmc_ai.commands.chat_command import ChatCommand
+from esbmc_ai.commands.help_command import HelpCommand
+
+
+class CommandRunner:
+    """Command runner manages running and storing commands."""
+
+    def __init__(self, builtin_commands: list[ChatCommand]) -> None:
+        self._builtin_commands: list[ChatCommand] = builtin_commands.copy()
+        self._addon_commands: list[ChatCommand] = []
+
+        # Set the help command commands
+        for cmd in self._builtin_commands:
+            if cmd.command_name == "help":
+                assert isinstance(cmd, HelpCommand)
+                cmd.commands = self.commands
+
+    @property
+    def commands(self) -> list[ChatCommand]:
+        return self._builtin_commands + self._addon_commands
+
+    @property
+    def command_names(self) -> list[str]:
+        return [cmd.command_name for cmd in self.commands]
+
+    @property
+    def builtin_commands_names(self) -> list[str]:
+        return [cmd.command_name for cmd in self._builtin_commands]
+
+    @property
+    def addon_commands_names(self) -> list[str]:
+        return [cmd.command_name for cmd in self._addon_commands]
+
+    @property
+    def addon_commands(self) -> list[ChatCommand]:
+        return self._addon_commands
+
+    @staticmethod
+    def parse_command(user_prompt_string: str) -> tuple[str, list[str]]:
+        """Parses a command and returns it based on the command rules outlined in
+        the wiki: https://github.com/Yiannis128/esbmc-ai/wiki/User-Chat-Mode"""
+        regex_pattern: str = (
+            r'\s+(?=(?:[^\\"]*(?:\\.[^\\"]*)*)$)|(?:(?<!\\)".*?(?<!\\)")|(?:\\.)+|\S+'
+        )
+        segments: list[str] = re.findall(regex_pattern, user_prompt_string)
+        parsed_array: list[str] = [segment for segment in segments if segment != " "]
+        # Remove all empty spaces.
+        command: str = parsed_array[0]
+        command_args: list[str] = parsed_array[1:]
+        return command, command_args

--- a/esbmc_ai/command_runner.py
+++ b/esbmc_ai/command_runner.py
@@ -1,3 +1,5 @@
+"""Contains code for managing and running built-in and addon commands."""
+
 import re
 from esbmc_ai.commands.chat_command import ChatCommand
 from esbmc_ai.commands.help_command import HelpCommand
@@ -18,22 +20,29 @@ class CommandRunner:
 
     @property
     def commands(self) -> list[ChatCommand]:
+        """Returns all commands. The list is copied."""
         return self._builtin_commands + self._addon_commands
 
     @property
     def command_names(self) -> list[str]:
+        """Returns a list of built-in commands. This is a reference to the
+        internal list."""
         return [cmd.command_name for cmd in self.commands]
 
     @property
     def builtin_commands_names(self) -> list[str]:
+        """Returns a list of built-in command names."""
         return [cmd.command_name for cmd in self._builtin_commands]
 
     @property
     def addon_commands_names(self) -> list[str]:
+        """Returns a list of the addon command names."""
         return [cmd.command_name for cmd in self._addon_commands]
 
     @property
     def addon_commands(self) -> list[ChatCommand]:
+        """Returns a list of the addon commands. This is a reference to the
+        internal list."""
         return self._addon_commands
 
     @staticmethod

--- a/esbmc_ai/commands/__init__.py
+++ b/esbmc_ai/commands/__init__.py
@@ -1,10 +1,10 @@
+"""This module contains built-in commands that can be executed by ESBMC-AI."""
+
 from .chat_command import ChatCommand
 from .exit_command import ExitCommand
 from .fix_code_command import FixCodeCommand, FixCodeCommandResult
 from .help_command import HelpCommand
 from .command_result import CommandResult
-
-"""This module contains built-in commands that can be executed by ESBMC-AI."""
 
 __all__ = [
     "ChatCommand",

--- a/esbmc_ai/commands/chat_command.py
+++ b/esbmc_ai/commands/chat_command.py
@@ -1,5 +1,7 @@
 # Author: Yiannis Charalambous
 
+"""Contains things related to chat commands."""
+
 from abc import ABC, abstractmethod
 from typing import Any, Optional
 
@@ -7,6 +9,8 @@ from esbmc_ai.commands.command_result import CommandResult
 
 
 class ChatCommand(ABC):
+    """Abstract Base Class for implementing chat commands."""
+
     def __init__(
         self,
         command_name: str = "",
@@ -20,4 +24,6 @@ class ChatCommand(ABC):
 
     @abstractmethod
     def execute(self, **kwargs: Optional[Any]) -> Optional[CommandResult]:
+        """The main entrypoint of the command. This is abstract and will need to
+        be implemented."""
         raise NotImplementedError(f"Command {self.command_name} is not implemented.")

--- a/esbmc_ai/commands/command_result.py
+++ b/esbmc_ai/commands/command_result.py
@@ -1,15 +1,22 @@
 # Author: Yiannis Charalambous
 
-from abc import abstractmethod
+"""Contains the base class for chat command results."""
+
+from abc import ABC, abstractmethod
 
 
-class CommandResult:
+class CommandResult(ABC):
+    """Base class for the return result of chat commands."""
+
     @property
     @abstractmethod
     def successful(self) -> bool:
+        """Returns true if the execution of the command was successful. False if
+        otherwise. If false, then it is up to the command to provide a method to
+        access the reason."""
         raise NotImplementedError()
 
     def __str__(self) -> str:
-        return f"Command returned " + (
+        return "Command returned " + (
             "successful" if self.successful else "unsuccessful"
         )

--- a/esbmc_ai/commands/exit_command.py
+++ b/esbmc_ai/commands/exit_command.py
@@ -1,5 +1,7 @@
 # Author: Yiannis Charalambous
 
+"""Contains the exit chat command."""
+
 import sys
 from typing import Any, Optional
 from typing_extensions import override
@@ -8,6 +10,8 @@ from .chat_command import ChatCommand
 
 
 class ExitCommand(ChatCommand):
+    """Used to exit user chat mode gracefully."""
+
     def __init__(self) -> None:
         super().__init__(
             command_name="exit",

--- a/esbmc_ai/commands/help_command.py
+++ b/esbmc_ai/commands/help_command.py
@@ -14,9 +14,6 @@ class HelpCommand(ChatCommand):
             help_message="Print this help message.",
         )
 
-    def set_commands(self, commands: list[ChatCommand]) -> None:
-        self.commands = commands
-
     @override
     def execute(self, **_: Optional[Any]) -> Optional[Any]:
         print()

--- a/esbmc_ai/commands/help_command.py
+++ b/esbmc_ai/commands/help_command.py
@@ -1,11 +1,16 @@
 # Author: Yiannis Charalambous
 
+"""Contains the help command."""
+
 from typing import Any, Optional
 from typing_extensions import override
 from .chat_command import ChatCommand
 
 
 class HelpCommand(ChatCommand):
+    """Command that prints helpful information about other commands. Including
+    addon commands."""
+
     commands: list[ChatCommand] = []
 
     def __init__(self) -> None:

--- a/esbmc_ai/config.py
+++ b/esbmc_ai/config.py
@@ -284,10 +284,8 @@ class Config:
             default_value=None,
             validate=lambda v: default_scenario in v
             and all(
-                [
-                    _validate_prompt_template(prompt_template)
-                    for prompt_template in v.values()
-                ]
+                _validate_prompt_template(prompt_template)
+                for prompt_template in v.values()
             ),
             on_read=lambda config_file: {
                 scenario: {

--- a/esbmc_ai/loading_widget.py
+++ b/esbmc_ai/loading_widget.py
@@ -10,7 +10,8 @@ from sys import stdout as terminal
 from time import sleep
 from itertools import cycle
 from threading import Thread
-from typing import Optional, override
+from typing import Optional
+from typing_extensions import override
 
 
 class BaseLoadingWidget:


### PR DESCRIPTION
This PR adds addon support for ESBMC-AI. Addons are modules that can be specified in the config using the field `addon_modules`, as a list of modules that export (using `__all__`) `ChatCommands` that are to be loaded.

A template repo for making addons is found here: github.com/Yiannis128/esbmc_ai_addon_template