### PR TITLE
Implement message prompt template variables error_line and error_type

### DIFF
--- a/esbmc_ai/chats/base_chat_interface.py
+++ b/esbmc_ai/chats/base_chat_interface.py
@@ -36,9 +36,12 @@ class BaseChatInterface(object):
 
     def push_to_message_stack(
         self,
-        message: BaseMessage,
+        message: BaseMessage | tuple[BaseMessage, ...] | list[BaseMessage],
     ) -> None:
-        self.messages.append(message)
+        if isinstance(message, list) or isinstance(message, tuple):
+            self.messages.extend(list(message))
+        else:
+            self.messages.append(message)
 
     def apply_template_value(self, **kwargs: str) -> None:
         """Will substitute an f-string in the message stack and system messages to

--- a/esbmc_ai/chats/base_chat_interface.py
+++ b/esbmc_ai/chats/base_chat_interface.py
@@ -42,7 +42,8 @@ class BaseChatInterface(object):
 
     def apply_template_value(self, **kwargs: str) -> None:
         """Will substitute an f-string in the message stack and system messages to
-        the provided value."""
+        the provided value. The new substituted messages will become the new
+        message stack, so the substitution is permanent."""
 
         system_message_prompts: PromptValue = self.ai_model.apply_chat_template(
             messages=self._system_messages,

--- a/esbmc_ai/chats/latest_state_solution_generator.py
+++ b/esbmc_ai/chats/latest_state_solution_generator.py
@@ -15,14 +15,19 @@ class LatestStateSolutionGenerator(SolutionGenerator):
 
     @override
     def generate_solution(
-        self, override_scenario: Optional[str] = None
+        self,
+        override_scenario: Optional[str] = None,
+        ignore_system_message: bool = False,
     ) -> tuple[str, FinishReason]:
         # Backup message stack and clear before sending base message. We want
         # to keep the message stack intact because we will print it with
         # print_raw_conversation.
         messages: list[BaseMessage] = self.messages
         self.messages: list[BaseMessage] = []
-        solution, finish_reason = super().generate_solution(override_scenario)
+        solution, finish_reason = super().generate_solution(
+            override_scenario=override_scenario,
+            ignore_system_message=ignore_system_message,
+        )
         # Append last messages to the messages stack
         messages.extend(self.messages)
         # Restore

--- a/esbmc_ai/chats/solution_generator.py
+++ b/esbmc_ai/chats/solution_generator.py
@@ -69,6 +69,12 @@ def get_esbmc_output_formatted(esbmc_output_type: str, esbmc_output: str) -> str
 
 
 class SolutionGenerator(BaseChatInterface):
+    """SolutionGenerator is a simple conversation-based automated program repair
+    class. The class works in a cycle, by first calling update_state with the
+    new source_code and esbmc_output, then by calling generate_solution. The
+    class supports scenarios to customize the system message and initial prompt
+    based on the"""
+
     def __init__(
         self,
         scenarios: FixCodeScenarios,
@@ -77,9 +83,7 @@ class SolutionGenerator(BaseChatInterface):
         source_code_format: str = "full",
         esbmc_output_type: str = "full",
     ) -> None:
-        """Initializes the solution generator. This ModelChat provides Dynamic
-        Prompting. Will get the correct scenario from the DynamicAIModelAgent
-        supplied and create a ChatPrompt."""
+        """Initializes the solution generator."""
 
         super().__init__(
             ai_model=ai_model,
@@ -96,6 +100,7 @@ class SolutionGenerator(BaseChatInterface):
         self.source_code_raw: Optional[str] = None
         self.source_code_formatted: Optional[str] = None
         self.esbmc_output: Optional[str] = None
+        self.invokations: int = 0
 
     @override
     def compress_message_stack(self) -> None:
@@ -103,6 +108,7 @@ class SolutionGenerator(BaseChatInterface):
         # If generate_solution is called after this point, it will start new
         # with the currently set state.
         self.messages: list[BaseMessage] = []
+        self.invokations = 0
 
     @classmethod
     def get_code_from_solution(cls, solution: str) -> str:
@@ -157,10 +163,48 @@ class SolutionGenerator(BaseChatInterface):
             esbmc_output=self.esbmc_output,
         )
 
+    def _get_system_messages(
+        self, override_scenario: Optional[str] = None
+    ) -> tuple[BaseMessage, ...]:
+        if override_scenario:
+            system_messages = self.scenarios[override_scenario]["system"]
+        else:
+            assert self.scenario, "Call update or set the scenario"
+            if self.scenario in self.scenarios:
+                system_messages = self.scenarios[self.scenario]["system"]
+            else:
+                system_messages = self.scenarios[default_scenario]["system"]
+
+        assert isinstance(system_messages, tuple)
+        assert all(isinstance(msg, BaseMessage) for msg in system_messages)
+        return system_messages
+
+    def _get_initial_message(self, override_scenario: Optional[str] = None) -> str:
+        if override_scenario:
+            return str(self.scenarios[override_scenario]["initial"])
+        else:
+            assert self.scenario, "Call update or set the scenario"
+            if self.scenario in self.scenarios:
+                return str(self.scenarios[self.scenario]["initial"])
+            else:
+                return str(self.scenarios[default_scenario]["initial"])
+
     def generate_solution(
         self,
         override_scenario: Optional[str] = None,
+        ignore_system_message: bool = False,
     ) -> tuple[str, FinishReason]:
+        """Prompts the LLM to repair the source code using the verifier output.
+        If this is the first time the method is called, the system message will
+        be sent to the LLM, unless ignore_system_message is True, in which case
+        the initial prompt will be used.
+
+        In subsequent invokations of generate_solution, the initial prompt will
+        be used.
+
+        So the system messages and initial message should each include at least
+        {source_code} and {esbmc_output} so that they are substituted into the
+        message."""
 
         assert (
             self.source_code_raw is not None
@@ -168,18 +212,18 @@ class SolutionGenerator(BaseChatInterface):
             and self.esbmc_output is not None
         ), "Call update_state before calling generate_solution."
 
-        # Get scenario initial message and push it to message stack
-        initial_message: str
-        if override_scenario:
-            initial_message = str(self.scenarios[override_scenario]["initial"])
+        if ignore_system_message or self.invokations > 0:
+            # Get scenario initial message and push it to message stack
+            self.push_to_message_stack(
+                HumanMessage(content=self._get_initial_message(override_scenario))
+            )
         else:
-            assert self.scenario, "Call update or set the scenario"
-            if self.scenario in self.scenarios:
-                initial_message = str(self.scenarios[self.scenario]["initial"])
-            else:
-                initial_message = str(self.scenarios[default_scenario])
+            # Get scenario system messages and push it to message stack. Don't
+            # push to system message stack because we want to regenerate from
+            # the beginning at every reset.
+            self.push_to_message_stack(self._get_system_messages(override_scenario))
 
-        self.push_to_message_stack(HumanMessage(content=initial_message))
+        self.invokations += 1
 
         # Apply template substitution to message stack
         self.apply_template_value(

--- a/esbmc_ai/chats/user_chat.py
+++ b/esbmc_ai/chats/user_chat.py
@@ -9,6 +9,7 @@ from langchain_community.chat_message_histories import ChatMessageHistory
 
 
 from esbmc_ai.ai_models import AIModel
+from esbmc_ai.esbmc_util import ESBMCUtil
 
 from .base_chat_interface import BaseChatInterface
 
@@ -37,8 +38,12 @@ class UserChat(BaseChatInterface):
         # The messsages for setting a new solution to the source code.
         self.set_solution_messages = set_solution_messages
 
-        self.apply_template_value(source_code=self.source_code)
-        self.apply_template_value(esbmc_output=self.esbmc_output)
+        self.apply_template_value(
+            source_code=self.source_code,
+            esbmc_output=self.esbmc_output,
+            error_line=str(ESBMCUtil.get_source_code_err_line(self.esbmc_output)),
+            error_type=ESBMCUtil.esbmc_get_error_type(self.esbmc_output),
+        )
 
     def set_solution(self, source_code: str) -> None:
         """Sets the solution to the problem ESBMC reported, this will inform the AI."""

--- a/esbmc_ai/config.py
+++ b/esbmc_ai/config.py
@@ -15,7 +15,6 @@ from typing import (
     List,
     NamedTuple,
     Optional,
-    Sequence,
 )
 
 from esbmc_ai.chat_response import list_to_base_messages
@@ -23,12 +22,13 @@ from esbmc_ai.logging import set_verbose
 from .ai_models import *
 from .api_key_collection import APIKeyCollection
 
-
-FixCodeScenarios = dict[str, dict[str, str | Sequence[BaseMessage]]]
+FixCodeScenarios = dict[str, dict[str, str | tuple[BaseMessage, ...]]]
 """Type for scenarios. A single scenario contains initial and system components.
 
 * Initial message can be accessed like so: `x["base"]["initial"]`
-* System message can be accessed like so: `x["base"]["system"]`"""
+* System messages can be accessed like so: `x["base"]["system"]`
+
+The config loader ensures they conform to the specifications."""
 
 default_scenario: str = "base"
 

--- a/esbmc_ai/esbmc_util.py
+++ b/esbmc_ai/esbmc_util.py
@@ -57,7 +57,25 @@ class ESBMCUtil:
 
     @classmethod
     def get_source_code_err_line(cls, esbmc_output: str) -> Optional[int]:
-        # Find "Violated property:" string in ESBMC output
+        """Gets the error line of the esbmc_output, by first using the counterexample
+        strategy, if that fails, then use clang."""
+        line: Optional[int] = ESBMCUtil.get_esbmc_err_line_idx(esbmc_output)
+        if not line:
+            # Check if it parses
+            line = ESBMCUtil.get_clang_err_line_idx(esbmc_output)
+        return line
+
+    @classmethod
+    def get_source_code_err_line_idx(cls, esbmc_output: str) -> Optional[int]:
+        line: Optional[int] = cls.get_source_code_err_line(esbmc_output)
+        if line:
+            return line - 1
+        else:
+            return None
+
+    @classmethod
+    def get_esbmc_err_line(cls, esbmc_output: str) -> Optional[int]:
+        """Find "Violated property:" string in ESBMC output"""
         violated_property: Optional[str] = cls.esbmc_get_violated_property(esbmc_output)
         if violated_property:
             # Get the line of the violated property.
@@ -70,8 +88,10 @@ class ESBMCUtil:
         return None
 
     @classmethod
-    def get_source_code_err_line_idx(cls, esbmc_output: str) -> Optional[int]:
-        line: Optional[int] = cls.get_source_code_err_line(esbmc_output)
+    def get_esbmc_err_line_idx(cls, esbmc_output: str) -> Optional[int]:
+        """Find "Violated property:" string in ESBMC output and return the line
+        as a 0-based index number."""
+        line: Optional[int] = cls.get_esbmc_err_line(esbmc_output)
         if line:
             return line - 1
         else:
@@ -94,7 +114,8 @@ class ESBMCUtil:
         return None
 
     @classmethod
-    def get_clang_err_line_index(cls, clang_output: str) -> Optional[int]:
+    def get_clang_err_line_idx(cls, clang_output: str) -> Optional[int]:
+        """Returns the clang error line as a 0-based index."""
         line: Optional[int] = cls.get_clang_err_line(clang_output)
         if line:
             return line - 1

--- a/esbmc_ai/esbmc_util.py
+++ b/esbmc_ai/esbmc_util.py
@@ -57,25 +57,25 @@ class ESBMCUtil:
 
     @classmethod
     def get_source_code_err_line(cls, esbmc_output: str) -> Optional[int]:
-        """Gets the error line of the esbmc_output, by first using the counterexample
-        strategy, if that fails, then use clang."""
-        line: Optional[int] = ESBMCUtil.get_esbmc_err_line_idx(esbmc_output)
+        """Gets the error line of the esbmc_output, regardless if it is a
+        counterexample or clang output."""
+        line: Optional[int] = cls.get_esbmc_err_line(esbmc_output)
         if not line:
-            # Check if it parses
-            line = ESBMCUtil.get_clang_err_line_idx(esbmc_output)
+            line = ESBMCUtil.get_clang_err_line(esbmc_output)
         return line
 
     @classmethod
     def get_source_code_err_line_idx(cls, esbmc_output: str) -> Optional[int]:
-        line: Optional[int] = cls.get_source_code_err_line(esbmc_output)
-        if line:
-            return line - 1
-        else:
-            return None
+        """Gets the error line index of the esbmc_output regardless if it is a
+        counterexample or clang output."""
+        line: Optional[int] = cls.get_source_code_err_line_idx(esbmc_output)
+        if not line:
+            return ESBMCUtil.get_clang_err_line_idx(esbmc_output)
+        return line - 1
 
     @classmethod
     def get_esbmc_err_line(cls, esbmc_output: str) -> Optional[int]:
-        """Find "Violated property:" string in ESBMC output"""
+        """Return from the counterexample the line where the error occurs."""
         violated_property: Optional[str] = cls.esbmc_get_violated_property(esbmc_output)
         if violated_property:
             # Get the line of the violated property.
@@ -89,8 +89,7 @@ class ESBMCUtil:
 
     @classmethod
     def get_esbmc_err_line_idx(cls, esbmc_output: str) -> Optional[int]:
-        """Find "Violated property:" string in ESBMC output and return the line
-        as a 0-based index number."""
+        """Return from the counterexample the line index where the error occurs."""
         line: Optional[int] = cls.get_esbmc_err_line(esbmc_output)
         if line:
             return line - 1

--- a/tests/test_base_chat_interface.py
+++ b/tests/test_base_chat_interface.py
@@ -40,6 +40,9 @@ def test_push_message_stack(setup) -> None:
         AIMessage(content="Test 1"),
         HumanMessage(content="Test 2"),
         SystemMessage(content="Test 3"),
+        SystemMessage(content="Test 4"),
+        SystemMessage(content="Test 5"),
+        SystemMessage(content="Test 6"),
     ]
 
     chat.push_to_message_stack(message=messages[0])
@@ -49,6 +52,12 @@ def test_push_message_stack(setup) -> None:
     assert chat.messages[0] == messages[0]
     assert chat.messages[1] == messages[1]
     assert chat.messages[2] == messages[2]
+
+    chat.push_to_message_stack(message=messages[3:])
+
+    assert chat.messages[3] == messages[3]
+    assert chat.messages[4] == messages[4]
+    assert chat.messages[5] == messages[5]
 
 
 def test_send_message(setup) -> None:

--- a/tests/test_esbmc_util.py
+++ b/tests/test_esbmc_util.py
@@ -22,22 +22,22 @@ def test_get_source_code_err_line(setup_get_data):
     data_esbmc_output: dict[str, str] = setup_get_data
 
     esbmc_output: str = data_esbmc_output["cartpole_48_safe.c-amalgamation-6.c"]
-    assert ESBMCUtil.get_source_code_err_line(esbmc_output) == 323
+    assert ESBMCUtil.get_esbmc_err_line(esbmc_output) == 323
 
     esbmc_output = data_esbmc_output["cartpole_92_safe.c-amalgamation-14.c"]
-    assert ESBMCUtil.get_source_code_err_line(esbmc_output) == 221
+    assert ESBMCUtil.get_esbmc_err_line(esbmc_output) == 221
 
     esbmc_output = data_esbmc_output["cartpole_95_safe.c-amalgamation-80.c"]
-    assert ESBMCUtil.get_source_code_err_line(esbmc_output) == 285
+    assert ESBMCUtil.get_esbmc_err_line(esbmc_output) == 285
 
     esbmc_output = data_esbmc_output["cartpole_26_safe.c-amalgamation-74.c"]
-    assert ESBMCUtil.get_source_code_err_line(esbmc_output) == 299
+    assert ESBMCUtil.get_esbmc_err_line(esbmc_output) == 299
 
     esbmc_output = data_esbmc_output["robot_5_safe.c-amalgamation-13.c"]
-    assert ESBMCUtil.get_source_code_err_line(esbmc_output) == 350
+    assert ESBMCUtil.get_esbmc_err_line(esbmc_output) == 350
 
     esbmc_output = data_esbmc_output["vdp_1_safe.c-amalgamation-28.c"]
-    assert ESBMCUtil.get_source_code_err_line(esbmc_output) == 247
+    assert ESBMCUtil.get_esbmc_err_line(esbmc_output) == 247
 
 
 def test_esbmc_get_counter_example(setup_get_data) -> None:

--- a/tests/test_reverse_order_solution_generator.py
+++ b/tests/test_reverse_order_solution_generator.py
@@ -56,13 +56,13 @@ def test_message_stack(setup_llm_model) -> None:
 
     solution_generator.update_state("", "")
 
-    solution, _ = solution_generator.generate_solution()
+    solution, _ = solution_generator.generate_solution(ignore_system_message=True)
     assert solution == llm.responses[0]
     solution_generator.scenarios[default_scenario]["initial"] = "Test message 2"
-    solution, _ = solution_generator.generate_solution()
+    solution, _ = solution_generator.generate_solution(ignore_system_message=True)
     assert solution == llm.responses[1]
     solution_generator.scenarios[default_scenario]["initial"] = "Test message 3"
-    solution, _ = solution_generator.generate_solution()
+    solution, _ = solution_generator.generate_solution(ignore_system_message=True)
     assert solution == llm.responses[2]
 
     # Test history is intact

--- a/tests/test_solution_generator.py
+++ b/tests/test_solution_generator.py
@@ -1,11 +1,12 @@
 # Author: Yiannis Charalambous
 
 from langchain.schema import AIMessage, HumanMessage, SystemMessage
-from langchain_core.language_models import FakeListLLM
+from langchain_core.language_models import FakeListChatModel, FakeListLLM
 import pytest
 
 from esbmc_ai.ai_models import AIModel
 from esbmc_ai.chats.solution_generator import SolutionGenerator
+from esbmc_ai.config import FixCodeScenarios
 
 
 @pytest.fixture(scope="function")
@@ -68,3 +69,53 @@ def test_get_code_from_solution():
         SolutionGenerator.get_code_from_solution("The repaired C code is:\n\n```\n```")
         == ""
     )
+
+
+def test_substitution() -> None:
+    with open(
+        "tests/samples/esbmc_output/line_test/cartpole_95_safe.c-amalgamation-80.c", "r"
+    ) as file:
+        esbmc_output: str = file.read()
+
+    chat = SolutionGenerator(
+        scenarios={
+            "base": {
+                "initial": "{source_code}{esbmc_output}{error_line}{error_type}",
+                "system": (
+                    SystemMessage(
+                        content="System:{source_code}{esbmc_output}{error_line}{error_type}"
+                    ),
+                ),
+            }
+        },
+        ai_model=AIModel("test", 10000000),
+        llm=FakeListChatModel(responses=["22222", "33333"]),
+        source_code_format="full",
+        esbmc_output_type="full",
+    )
+
+    chat.update_state("11111", esbmc_output)
+    chat.generate_solution(ignore_system_message=False)
+
+    assert (
+        chat.messages[0].content
+        == "System:11111"
+        + esbmc_output
+        + str(285)
+        + "dereference failure: Access to object out of bounds"
+    )
+
+    assert chat.messages[1].content == "22222"
+
+    chat.update_state("11111", esbmc_output)
+    chat.generate_solution(ignore_system_message=False)
+
+    assert (
+        chat.messages[2].content
+        == "11111"
+        + esbmc_output
+        + str(285)
+        + "dereference failure: Access to object out of bounds"
+    )
+
+    assert chat.messages[3].content == "33333"

--- a/tests/test_solution_generator.py
+++ b/tests/test_solution_generator.py
@@ -6,7 +6,6 @@ import pytest
 
 from esbmc_ai.ai_models import AIModel
 from esbmc_ai.chats.solution_generator import SolutionGenerator
-from esbmc_ai.config import FixCodeScenarios
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
Implemented the following chat prompt template variables:

* `error_line`
* `error_type`
- [x] Add tests for this

Closes #115