### PR TITLE
readline module import removed

### DIFF
--- a/esbmc_ai/__main__.py
+++ b/esbmc_ai/__main__.py
@@ -4,7 +4,6 @@
 
 import sys
 
-import readline
 import argparse
 from typing import Any
 
@@ -19,9 +18,6 @@ from esbmc_ai.verifiers.base_source_verifier import BaseSourceVerifier
 from esbmc_ai.verifiers.esbmc import ESBMC
 from esbmc_ai.component_loader import ComponentLoader
 import esbmc_ai.commands
-
-# Enables arrow key functionality for input(). Do not remove import.
-_ = readline
 
 HELP_MESSAGE: str = (
     "Automated Program Repair platform. To view help on subcommands, run with "

--- a/esbmc_ai/ai_models.py
+++ b/esbmc_ai/ai_models.py
@@ -488,6 +488,7 @@ class AIModels(metaclass=SingletonMeta):
                 api_key=api_key,
                 refresh_duration_seconds=refresh_duration_seconds,
             )
+            """
         self._load_ai_model_list(
             source_name="OpenAI",
             cache_name="openai_models.txt",
@@ -508,7 +509,7 @@ class AIModels(metaclass=SingletonMeta):
                 tokens=AIModelAnthropic.get_max_tokens(v),
             ),
         )
-
+"""
     @property
     def model_names(self) -> list[str]:
         return list(self._ai_models.keys())

--- a/esbmc_ai/ai_models.py
+++ b/esbmc_ai/ai_models.py
@@ -123,6 +123,60 @@ class AIModel(ABC):
 
         template = Template(content)
         return template.safe_substitute(**values)
+        def add_safeguards(content: str, char: str, allowed_keys: list[str]) -> str:
+            start_idx: int = 0
+            while True:
+                char_idx: int = content.find(char, start_idx)
+                if char_idx == -1:
+                    break
+                # Count how many sequences of the char are occuring
+                count: int = 1
+                while (
+                    len(content) > char_idx + count
+                    and content[char_idx + count] == char
+                ):
+                    count += 1
+
+                # Check if the next sequence is in the allowed keys, if it is, then
+                # skip to the next one.
+                is_allowed: bool = False
+                for key in allowed_keys:
+                    if key == content[char_idx + count : char_idx + count + len(key)]:
+                        is_allowed = True
+                        break
+
+                # Now change start_idx to reflect new location. The start index is at the end of
+                # all the chars (including the inserted one).
+                start_idx = char_idx + count + 1
+
+                # If inside allowed keys, then continue to next iteration.
+                if is_allowed:
+                    continue
+
+                # Check if odd number (will need to add extra char)
+                if count % 2 != 0:
+                    content = (
+                        content[: char_idx + count] + char + content[char_idx + count :]
+                    )
+            return content
+
+        reversed_keys: list[str] = [key[::-1] for key in allowed_keys]
+
+        result: list[BaseMessage] = []
+        for msg in messages:
+            content: str = str(msg.content)
+            look_pointer: int = 0
+            # Open curly check
+            if content.find("{", look_pointer) != -1:
+                content = add_safeguards(content, "{", allowed_keys)
+            # Close curly check
+            if content.find("}", look_pointer) != -1:
+                # Do it in reverse with reverse keys.
+                content = add_safeguards(content[::-1], "}", reversed_keys)[::-1]
+            new_msg = msg.model_copy()
+            new_msg.content = content
+            result.append(new_msg)
+        return result
 
     def apply_chat_template(
         self,

--- a/esbmc_ai/ai_models.py
+++ b/esbmc_ai/ai_models.py
@@ -231,7 +231,6 @@ class AIModelOpenAI(AIModelService):
             reasoning_effort="high" if self._reason_model else None,
             max_retries=self.requests_max_tries,
             timeout=self.requests_timeout,
-            api_key=SecretStr(self.api_key) or None,
             model_kwargs={},
             **kwargs,
         )
@@ -293,6 +292,7 @@ class AIModelOpenAI(AIModelService):
     def get_canonical_name(cls) -> str:
         """Get the canonical name of the OpenAI service."""
         return "openai"
+
 
 @dataclass(frozen=True, kw_only=True)
 class OllamaAIModel(AIModel):

--- a/esbmc_ai/base_config.py
+++ b/esbmc_ai/base_config.py
@@ -29,7 +29,7 @@ class BaseConfig(ABC):
         self.config_file: dict[str, Any]
         self.on_load_value: list[Callable[[str], None]] = []
 
-    def load_config_fields(self, cfg_path: Path, fields: list[ConfigField],cfg:PurePath) -> None:
+    def load_config_fields(self, cfg_path: Path, fields: list[ConfigField],cfg:PurePath=None) -> None:
         """Initializes the base config structures. Loads the config file and fields."""  
         #match the system name to ensure backslashes in windows are handled
         match system_name():

--- a/esbmc_ai/commands/fix_code_command.py
+++ b/esbmc_ai/commands/fix_code_command.py
@@ -1,8 +1,9 @@
 # Author: Yiannis Charalambous
 
 import os
-from pathlib import Path
+from pathlib import Path, PurePath
 import sys
+import argparse #import added to resolve filepath issue
 from typing import Any, Optional
 from langchain.schema import HumanMessage
 from typing_extensions import override
@@ -154,11 +155,22 @@ class FixCodeCommand(ChatCommand):
     def execute(self, **kwargs: Any) -> FixCodeCommandResult:
         ComponentLoader().load_base_component_config(self)
 
-        # Handle kwargs
+        #get base path and list of filepaths from the config
+        path=Path(os.getcwd())
+        list_path=self.get_config_value("solution.filenames")
+
+        #a second arg parse is introduced
+        parser = argparse.ArgumentParser()
+        parser.add_argument("fix-code")
+        parser.add_argument("echo")
+        args = parser.parse_args()
+
+
+        # Handle kwargs  
         source_file: SourceFile = SourceFile.load(
-            self.get_config_value("solution.filenames")[0],
-            Path(os.getcwd()),
-        )
+            (list_path[0] if len(list_path) else Path(f"{args.echo}")), #args taken from command line if list_path is null
+            path,
+            )
         original_source_file: SourceFile = SourceFile(
             source_file.file_path, source_file.base_path, source_file.content
         )

--- a/esbmc_ai/config.py
+++ b/esbmc_ai/config.py
@@ -6,13 +6,12 @@ import logging
 import os
 import sys
 from platform import system as system_name
-from pathlib import Path
+from pathlib import Path, PurePath
 from typing import (
     Any,
     override,
 )
 import argparse
-
 from dotenv import load_dotenv, find_dotenv
 import structlog
 
@@ -350,7 +349,6 @@ class Config(BaseConfig, metaclass=makecls(SingletonMeta)):
         self._load_args(args, fields)
         # Base init needs to be called last
         self.load_config_fields(self.get_value("ESBMCAI_CONFIG_FILE"), fields)
-
         # =============== Post Init - Set to good values to fields ============
         # Add logging handlers with config options
         logging_handlers: list[logging.Handler] = []
@@ -547,7 +545,7 @@ class Config(BaseConfig, metaclass=makecls(SingletonMeta)):
                 fields_set.add(reverse_mappings[mapped_name])
 
         load_fields: list[ConfigField] = [f for f in fields if f.name not in fields_set]
-        return super().load_config_fields(cfg_path, load_fields)
+        return super().load_config_fields(cfg_path, load_fields, cfg_path)
 
     def _filenames_load(self, file_names: list[str]) -> list[Path]:
         """Loads the filenames from the command line first then from the config."""

--- a/tests/regtest/test_base_chat_interface.py
+++ b/tests/regtest/test_base_chat_interface.py
@@ -16,6 +16,9 @@ def setup() -> BaseChatInterface:
     responses: list[str] = ["OK 1", "OK 2", "OK 3"]
 
     ai_model: AIModel = MockAIModel(name="test", tokens=1024, responses=responses)
+    ai_model: AIModel = MockAIModel(
+        name="test", tokens=1024, responses=responses
+    ).bind()
     assert isinstance(ai_model, MockAIModel)
 
     system_messages = [

--- a/tests/test_base_chat_interface.py
+++ b/tests/test_base_chat_interface.py
@@ -1,7 +1,5 @@
 # Author: Yiannis Charalambous
 
-from langchain_core.language_models import FakeListChatModel
-from openai import responses
 import pytest
 
 from langchain.schema import AIMessage, BaseMessage, HumanMessage, SystemMessage

--- a/tests/test_base_chat_interface.py
+++ b/tests/test_base_chat_interface.py
@@ -1,5 +1,7 @@
 # Author: Yiannis Charalambous
 
+from langchain_core.language_models import FakeListChatModel
+from openai import responses
 import pytest
 
 from langchain.schema import AIMessage, BaseMessage, HumanMessage, SystemMessage
@@ -63,6 +65,7 @@ def test_send_message(setup) -> None:
     chat: BaseChatInterface = BaseChatInterface(
         system_messages=system_messages,
         ai_model=ai_model,
+        ai_model=ai_model.bind(),
     )
 
     chat_responses: list[ChatResponse] = [


### PR DESCRIPTION
Readline module in file __main.py__ removed, and it's usage in the same file "_=readline as well". This resolves the "No module named readline" exception that may occur